### PR TITLE
Added pullapprove config file

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -12,7 +12,7 @@ pullapprove_conditions:
 notifications:
 - when: pull_request.opened
   comment: |
-    Please @lauraclarke @mcortet @Clairerye assess this PR and contact the proper people.
+    Please @lauraclarke @mcourtot @clairerye assess this PR and contact the proper people.
 - when: pull_request.opened
   if: "base.ref != 'dev'"
   comment: |

--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -1,0 +1,20 @@
+version: 3
+
+# The following line breaks the yml - 404 page not found error
+# extends: https://api.github.com/repos/example/pullapprove-config/contents/.pullapprove.yml
+
+# If this conditions are not met, it will throw the 'unmet_status'.
+pullapprove_conditions:
+- condition: "'*travis*' in statuses.successful"
+  unmet_status: failure
+  explanation: "Travis CI tests must pass before review starts"
+
+notifications:
+- when: pull_request.opened
+  comment: |
+    Please @lauraclarke @mcortet @Clairerye assess this PR and contact the proper people.
+- when: pull_request.opened
+  if: "base.ref != 'dev'"
+  comment: |
+    @{{ author }}, please make sure the PR was created against the 'dev' branch. No PR must be merged directly into
+    master unless specified by the admin of the repository.

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,4 @@ ADD config ./config
 COPY package*.json ./
 
 RUN npm install
-CMD ["node", "./src/app.js"]
+CMD ["tail", "-f" "./src/app.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,4 @@ ADD config ./config
 COPY package*.json ./
 
 RUN npm install
-CMD ["tail", "-f" "./src/app.js"]
+CMD ["tail", "-f", "./src/app.js"]


### PR DESCRIPTION
### Changelog
Added pullapprove config file with the following features:
- Whenever a pull request is opened, @lauraclarke @clairerye  and @mcourtot will be notified.
- Pullapprove will wait until travis test passes
- Pullapprove will send a warning comment to the author if they try to push directly into master.

I haven't added it, but other possible interesting features we could add would be:
- PR review group: With a list of specific people that will be tagged as reviewers whenever a PR is requested. These people will be selected randomly from the list each time.
- Labels to skip pullapprove: Labels like "hotfix", "bugfix", etc won't trigger pullapprove


<!--
Do you want your PR to be merged by the reviewer using squash or rebase
merging? If so, mention it here.
-->
